### PR TITLE
Update Dockerfile to lock bundler version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN echo $TZ > /etc/timezone && \
       dpkg-reconfigure -f noninteractive tzdata && \
       apt-get clean
 
-RUN gem install bundler
+RUN gem install bundler:2.0.1
 
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
As this file stands, this may not build correctly and will only fail at runtime.